### PR TITLE
WAZO-820 remove exception filtering in ProvdError

### DIFF
--- a/wazo_provd_client/command.py
+++ b/wazo_provd_client/command.py
@@ -17,10 +17,7 @@ class ProvdCommand(RESTCommand):
         if response.status_code == 503:
             raise ProvdServiceUnavailable(response)
 
-        try:
-            raise ProvdError(response=response)
-        except InvalidProvdError:
-            RESTCommand.raise_from_response(response)
+        RESTCommand.raise_from_response(response)
 
     @staticmethod
     def _build_list_params(search=None, fields=None, offset=0, limit=0, order=None, direction=None, *args, **kwargs):

--- a/wazo_provd_client/exceptions.py
+++ b/wazo_provd_client/exceptions.py
@@ -5,24 +5,7 @@ from requests import HTTPError, codes
 
 
 class ProvdError(HTTPError):
-
-    def __init__(self, *args, **kwargs):
-        response = kwargs.get('response', None)
-        self.status_code = getattr(response, 'status_code', None)
-        self.message = getattr(response, 'text', None)
-        valid_provd_errors = (
-            codes.bad_request,
-            codes.unsupported_media_type,
-            codes.not_found,
-            codes.server_error,
-            codes.unauthorized,
-        )
-        if self.status_code not in valid_provd_errors:
-            raise InvalidProvdError()
-
-        exception_message = '{e.message}'.format(e=self)
-        super(ProvdError, self).__init__(exception_message, *args, **kwargs)
-
+    pass
 
 class ProvdServiceUnavailable(Exception):
     pass

--- a/wazo_provd_client/tests/test_command.py
+++ b/wazo_provd_client/tests/test_command.py
@@ -1,4 +1,4 @@
-# Copyright 2018 The Wazo Authors  (see AUTHORS file)
+# Copyright 2018-2019 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from unittest import TestCase
@@ -46,7 +46,5 @@ class TestProvdCommand(TestCase):
     def test_raise_from_response_default_error(self):
         response = Mock(status_code=404)
 
-        assert_that(
-            calling(ProvdCommand.raise_from_response).with_args(response),
-            raises(ProvdError)
-        )
+        ProvdCommand.raise_from_response(response)
+        response.raise_for_status.assert_called_once()


### PR DESCRIPTION
reason: it is not useful to filter based on status codes.